### PR TITLE
Fix broken link, add resume link and replace teacher for educator

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,11 @@
             </a>
           </li>
           <li>
+            <a target="_blank" rel="noopener" href="https://resume.michelletorres.dev" aria-label="Resume">
+              <i class="far fa-file" aria-hidden="true" title="Resume"></i>
+            </a>
+          </li>
+          <li>
             <a target="_blank" rel="noopener" href="https://github.com/nmicht" aria-label="GitHub">
               <i class="fab fa-github" aria-hidden="true" title="GitHub"></i>
             </a>
@@ -124,6 +129,12 @@
         <a target="_blank" rel="noopener" href="https://www.linkedin.com/in/michelletorresv" title="LinkedIn">
           <i class="fab fa-linkedin-in" aria-hidden="true" title="LinkedIn"></i>
           LinkedIn
+        </a>
+      </li>
+      <li>
+        <a target="_blank" rel="noopener" href="https://resume.michelletorres.dev" title="Resume">
+          <i class="far fa-file" aria-hidden="true" title="Resume"></i>
+          Resume
         </a>
       </li>
       <li>

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
             </a>
           </li>
           <li>
-            <a target="_blank" rel="noopener" href="https://videos.yosoy.dev" aria-label="YouTube">
+            <a target="_blank" rel="noopener" href="https://www.youtube.com/c/yosoydev" aria-label="YouTube">
               <i class="fab fa-youtube" aria-hidden="true" title="YouTube"></i>
             </a>
           </li>
@@ -107,7 +107,7 @@
         University of Guadalajara in Mexico.</p>
         <p>I speak at conferences and share my experience and knowledge in any possible way. I love talking about open-source, free
         software, leadership, career development, collaboration, and software development. I am committed to promoting diversity, equity, and inclusion in tech.</p>
-        <p>I ran a <a target="_blank" rel="noopener" href="https://yosoy.dev" alt="Yo Soy Dev Blog" title="Blog">blog</a> and a <a target="_blank" rel="noopener" href="https://videos.yosoy.dev" title="YouTube channel">video channel</a> with content for students and people interested in learning web development. Unfortunately, it is currently idle.</p>
+        <p>I ran a <a target="_blank" rel="noopener" href="https://yosoy.dev" alt="Yo Soy Dev Blog" title="Blog">blog</a> and a <a target="_blank" rel="noopener" href="https://www.youtube.com/c/yosoydev" title="YouTube channel">video channel</a> with content for students and people interested in learning web development. Unfortunately, it is currently idle.</p>
         <p>In my spare time, I enjoy cooking, trying new food, reading a good book, and traveling.</p>
       </article>
       <article class="">
@@ -139,7 +139,7 @@
         </a>
       </li>
       <li>
-        <a target="_blank" rel="noopener" href="https://videos.yosoy.dev" title="YouTube">
+        <a target="_blank" rel="noopener" href="https://www.youtube.com/c/yosoydev" title="YouTube">
           <i class="fab fa-youtube" aria-hidden="true" title="YouTube"></i>
           YouTube
         </a>

--- a/index.html
+++ b/index.html
@@ -103,10 +103,10 @@
       <article class="">
         <h2>Hello!</h2>
         <p>I am an Engineering Leader focused on empowering and supporting leaders and engineers to deliver exceptional results.</p>
-        <p>I worked for several years as an individual contributor and as a tech lead. Before moving to Germany, I was a teacher for 10 years at the
+        <p>I worked for several years as an individual contributor and as a tech lead. I was a Bachelor of Computer Science teacher for ten years at the
         University of Guadalajara in Mexico.</p>
-        <p>I speak at conferences and share my experience and knowledge in any possible way. I love talking about open-source, free
-        software, leadership, career development, collaboration, and software development. I am committed to promoting diversity, equity, and inclusion in tech.</p>
+        <p>I am committed to promoting diversity, equity, and inclusion in tech. I speak at conferences and share my experience and knowledge in any possible way. I love talking about open-source, free
+        software, leadership, career development, collaboration, and software development.</p>
         <p>I ran a <a target="_blank" rel="noopener" href="https://yosoy.dev" alt="Yo Soy Dev Blog" title="Blog">blog</a> and a <a target="_blank" rel="noopener" href="https://www.youtube.com/c/yosoydev" title="YouTube channel">video channel</a> with content for students and people interested in learning web development. Unfortunately, it is currently idle.</p>
         <p>In my spare time, I enjoy cooking, trying new food, reading a good book, and traveling.</p>
       </article>

--- a/index.html
+++ b/index.html
@@ -6,12 +6,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Michelle Torres | Engineering Leader</title>
-    <meta name="description" content="Engineering Leader • Teacher • Speaker • Free & Open Source advocate • Foodie & Traveler"/>
+    <meta name="description" content="Engineering Leader • Educator • Speaker • Free & Open Source advocate • Foodie & Traveler"/>
     <link rel="canonical" href="https://michelletorres.dev" />
     <meta property="og:locale" content="en" />
     <meta property="og:type" content="article" />
     <meta property="og:title" content="Michelle Torres | Engineering Leader" />
-    <meta property="og:description" content="Engineering Leader • Teacher • Speaker • Free & Open Source advocate • Foodie & Traveler" />
+    <meta property="og:description" content="Engineering Leader • Educator • Speaker • Free & Open Source advocate • Foodie & Traveler" />
     <meta property="og:url" content="https://michelletorres.dev" />
     <meta property="og:site_name" content="michelletorres.dev" />
     <meta property="og:image" content="https://michelletorres.dev/img/michelletorres-avatar.jpg" />
@@ -20,7 +20,7 @@
     <meta property="og:image:height" content="340" />
     <meta property="og:image:alt" content="Michelle Torres | Engineering Leader" />
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:description" content="Engineering Leader • Teacher • Speaker • Free & Open Source advocate • Foodie & Traveler" />
+    <meta name="twitter:description" content="Engineering Leader • Educator • Speaker • Free & Open Source advocate • Foodie & Traveler" />
     <meta name="twitter:title" content="Michelle Torres | Engineering Leader" />
     <meta name="twitter:site" content="@nmicht" />
     <meta name="twitter:image" content="https://michelletorres.dev/img/michelletorres-avatar.jpg" />
@@ -96,7 +96,7 @@
         </li>
       </ul>
 
-      <p>Engineering Leader <span class="bullet">•</span> Teacher <span class="bullet">•</span> Speaker <span class="bullet">•</span> Free & Open Source advocate <span class="bullet">•</span> Foodie & Traveler</p>
+      <p>Engineering Leader <span class="bullet">•</span> Educator <span class="bullet">•</span> Speaker <span class="bullet">•</span> Free & Open Source advocate <span class="bullet">•</span> Foodie & Traveler</p>
     </header>
 
     <main class="fixed">


### PR DESCRIPTION
Another bunch of changes as part of my updates for 2024

## Remove the information about my location in Germany
I don't think it makes sense to share that I live in Germany. It's okay to say I was a teacher in Mexico, but not that I moved to another country.

## Fix the link to videos
The subdomain redirect of yosoydev is not working. Before digging more into the configuration, I decided for the moment to link directly to the YouTube channel. 

## Replace "Teacher" for "Educator"
This required some deep thought. After reading https://www.edmentum.com/intl/articles/are-you-a-teacher-or-an-educator/, I decided to update to Educator because my journey is not just a job but a vocation.

## Add resume
I published my Gdoc resume, so it doesn't hurt to have a link here. I'm using the simple file icon because my imagination doesn't give me to pick something else.